### PR TITLE
CI update: Polish Language Fix & Autmotaic Removal of old bot's comments

### DIFF
--- a/.github/workflows/polish-check.yml
+++ b/.github/workflows/polish-check.yml
@@ -22,16 +22,21 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Check for Polish characters
+      - name: Check for Polish characters in diff
         run: |
           FOUND=0
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             if [ -f "$file" ]; then
-              grep -nP "[ąęćłńóśźżĄĘĆŁŃÓŚŹŻ]" "$file" && FOUND=1 && echo "Found Polish in $file"
+              if git diff -U0 "origin/${{ github.base_ref }}" -- "$file" | grep "^+" | grep -v "^+++" | grep -q "[ąęćłńóśźżĄĘĆŁŃÓŚŹŻ]"; then
+                echo "Found new Polish characters in $file"
+                git diff -U0 "origin/${{ github.base_ref }}" -- "$file" | grep "^+" | grep -v "^+++" | grep "[ąęćłńóśźżĄĘĆŁŃÓŚŹŻ]"
+                FOUND=1
+              fi
             fi
           done <<< "${{ steps.files.outputs.changed_files }}"
+
           if [ $FOUND -eq 1 ]; then
-            echo "::error title=Polish Language Detected::Found Polish characters (comments/strings). Check logs."
+            echo "::error title=Polish Language Detected::New Polish characters found in added lines. Check logs."
             exit 1
           fi

--- a/.github/workflows/polish-check.yml
+++ b/.github/workflows/polish-check.yml
@@ -14,7 +14,11 @@ jobs:
         run: |
           {
             echo "changed_files<<EOF"
-            git diff --name-only "origin/${{ github.base_ref }}" -- . ':(exclude)docs/**'
+            # docs can be in Polish, UI is in Polish, this file has Polish characters -> so we exclude those
+            git diff --name-only "origin/${{ github.base_ref }}" -- . \
+              ':(exclude)docs/**' \
+              ':(exclude)mobile/**' \
+              ':(exclude).github/workflows/polish-check.yml'
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/polish-check.yml
+++ b/.github/workflows/polish-check.yml
@@ -12,15 +12,24 @@ jobs:
       - name: Get changed files
         id: files
         run: |
-          echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} | grep -v '^docs/' | xargs)" >> $GITHUB_OUTPUT
+          {
+            echo "changed_files<<EOF"
+            git diff --name-only "origin/${{ github.base_ref }}" -- . ':(exclude)docs/**'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check for Polish characters
         run: |
-          FILES="${{ steps.files.outputs.changed_files }}"
           FOUND=0
-          for file in $FILES; do
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
             if [ -f "$file" ]; then
               grep -nP "[ąęćłńóśźżĄĘĆŁŃÓŚŹŻ]" "$file" && FOUND=1 && echo "Found Polish in $file"
+            fi
+          done <<< "${{ steps.files.outputs.changed_files }}"
+          if [ $FOUND -eq 1 ]; then
+            echo "::warning title=Polish Language Detected::Found polish characters (comments/strings). Check logs."
+          fi
             fi
           done
           if [ $FOUND -eq 1 ]; then

--- a/.github/workflows/polish-check.yml
+++ b/.github/workflows/polish-check.yml
@@ -1,0 +1,28 @@
+name: Polish Language Check
+on: [pull_request]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: files
+        run: |
+          echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} | grep -v '^docs/' | xargs)" >> $GITHUB_OUTPUT
+
+      - name: Check for Polish characters
+        run: |
+          FILES="${{ steps.files.outputs.changed_files }}"
+          FOUND=0
+          for file in $FILES; do
+            if [ -f "$file" ]; then
+              grep -nP "[ąęćłńóśźżĄĘĆŁŃÓŚŹŻ]" "$file" && FOUND=1 && echo "Found Polish in $file"
+            fi
+          done
+          if [ $FOUND -eq 1 ]; then
+            echo "::warning title=Polish Language Detected::Found polish characters (comments/strings). Check logs."
+          fi

--- a/.github/workflows/polish-check.yml
+++ b/.github/workflows/polish-check.yml
@@ -34,8 +34,3 @@ jobs:
           if [ $FOUND -eq 1 ]; then
             echo "::warning title=Polish Language Detected::Found polish characters (comments/strings). Check logs."
           fi
-            fi
-          done
-          if [ $FOUND -eq 1 ]; then
-            echo "::warning title=Polish Language Detected::Found polish characters (comments/strings). Check logs."
-          fi

--- a/.github/workflows/polish-check.yml
+++ b/.github/workflows/polish-check.yml
@@ -32,5 +32,6 @@ jobs:
             fi
           done <<< "${{ steps.files.outputs.changed_files }}"
           if [ $FOUND -eq 1 ]; then
-            echo "::warning title=Polish Language Detected::Found polish characters (comments/strings). Check logs."
+            echo "::error title=Polish Language Detected::Found Polish characters (comments/strings). Check logs."
+            exit 1
           fi

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,35 @@
+name: PR Comment Cleanup
+
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    
+    steps:
+      - name: Delete old bot comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botLogins = ['coderabbitai[bot]', 'github-actions[bot]'];
+
+            for (const comment of comments) {
+              if (botLogins.includes(comment.user.login)) {
+                console.log(`Deleting comment ${comment.id} from ${comment.user.login}`);
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }


### PR DESCRIPTION
Closes #34 
Closes #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Coderabbit's summary:

- **Polish Language Check** (`.github/workflows/polish-check.yml`): New workflow that runs on pull requests and detects Polish-language content by scanning only added lines in changed files, excluding docs and mobile directories. Fails the CI check if Polish characters are detected.

- **PR Comment Cleanup** (`.github/workflows/pr-cleanup.yml`): New workflow that automatically removes comments posted by `coderabbitai[bot]` and `github-actions[bot]` when a PR is updated, reducing bot spam and keeping PR threads clean.

- Both workflows address the stated objectives from issues #34 and #35 to improve CI Polish language detection and reduce bot clutter in pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->