### PR TITLE
Progress steps on frontend

### DIFF
--- a/mobile/AnalyzingView.swift
+++ b/mobile/AnalyzingView.swift
@@ -1,12 +1,34 @@
 import SwiftUI
 
+// Backend steps (from /analyze-glaucoma-stream):
+//  step 1 – image received
+//  step 2 – loading AI models (only on cold start)
+//  step 3 – running AI inference
+//  step 4 – processing masks
+//  step 5 – success (final result)
+
 // Analyzing Screen
 struct AnalyzingView: View {
+    @ObservedObject var vm: GlaucomaViewModel
+
     @State private var rotation: Double = 0
     @State private var pulse: Bool = false
     @State private var dots: Int = 0
 
     let timer = Timer.publish(every: 0.45, on: .main, in: .common).autoconnect()
+
+    // Map backend step → which UI steps are "done" (steps 1-4 in UI)
+    // UI step 1: Wgrywanie obrazu       → backend step >= 2
+    // UI step 2: Detekcja tarczy        → backend step >= 3
+    // UI step 3: Pomiar wskaźnika C/D   → backend step >= 4
+    // UI step 4: Klasyfikacja AI        → backend step >= 5
+    private func isDone(_ uiStep: Int) -> Bool {
+        vm.analysisStep >= uiStep + 1
+    }
+
+    private func isActive(_ uiStep: Int) -> Bool {
+        vm.analysisStep == uiStep
+    }
 
     var body: some View {
         ZStack {
@@ -24,14 +46,14 @@ struct AnalyzingView: View {
 
                 // circles animation
                 ZStack {
-                    // outer
+                    // outer rings
                     ForEach(0..<3, id: \.self) { i in
                         Circle()
                             .stroke(Color.accentCyan.opacity(0.08 - Double(i) * 0.02), lineWidth: 1)
                             .frame(width: CGFloat(100 + i * 50), height: CGFloat(100 + i * 50))
                     }
 
-                    // spinning
+                    // spinning arc
                     Circle()
                         .trim(from: 0, to: 0.28)
                         .stroke(
@@ -44,7 +66,7 @@ struct AnalyzingView: View {
                         .frame(width: 100, height: 100)
                         .rotationEffect(.degrees(rotation))
 
-                    // pulse
+                    // pulse glow
                     Circle()
                         .fill(Color.accentCyan.opacity(pulse ? 0.15 : 0.05))
                         .frame(width: 60, height: 60)
@@ -64,7 +86,7 @@ struct AnalyzingView: View {
                     }
                 }
 
-                // text
+                // text header
                 VStack(spacing: 10) {
                     HStack(spacing: 4) {
                         Text("ANALIZOWANIE")
@@ -77,23 +99,53 @@ struct AnalyzingView: View {
                             .frame(width: 24, alignment: .leading)
                     }
 
-                    Text("Model AI przetwarza obraz dna oka")
+                    Text(stepDescription(vm.analysisStep))
                         .font(.system(size: 13))
                         .foregroundStyle(Color.textSecondary)
+                        .animation(.easeInOut(duration: 0.3), value: vm.analysisStep)
                 }
 
-                // TODO: Progress steps
+                // Progress steps — driven by real backend steps
                 VStack(spacing: 10) {
-                    ProgressStep(label: "Wgrywanie obrazu", done: true)
-                    ProgressStep(label: "Detekcja tarczy wzrokowej", done: dots > 1)
-                    ProgressStep(label: "Pomiar wskaźnika C/D", done: dots > 2)
-                    ProgressStep(label: "Klasyfikacja AI", done: false, active: true)
+                    ProgressStep(
+                        label: "Wgrywanie obrazu",
+                        done: isDone(1),
+                        active: isActive(1)
+                    )
+                    ProgressStep(
+                        label: "Detekcja tarczy wzrokowej",
+                        done: isDone(2),
+                        active: isActive(2) || isActive(3)   // steps 2+3 both "run AI"
+                    )
+                    ProgressStep(
+                        label: "Pomiar wskaźnika C/D",
+                        done: isDone(3),
+                        active: isActive(4)
+                    )
+                    ProgressStep(
+                        label: "Klasyfikacja AI",
+                        done: isDone(4),
+                        active: isActive(5)
+                    )
                 }
                 .padding(.horizontal, 48)
             }
         }
         .onReceive(timer) { _ in
             dots = (dots + 1) % 4
+        }
+    }
+
+    // Human-readable description for each backend step
+    private func stepDescription(_ step: Int) -> String {
+        switch step {
+        case 0:  return "Łączenie z serwerem..."
+        case 1:  return "Obraz odebrany — inicjalizacja modeli"
+        case 2:  return "Ładowanie modeli AI (YOLO i UNet)"
+        case 3:  return "Model AI przetwarza obraz dna oka"
+        case 4:  return "Nakładanie masek segmentacji"
+        case 5:  return "Analiza zakończona pomyślnie"
+        default: return "Przetwarzanie..."
         }
     }
 }
@@ -119,9 +171,13 @@ struct ProgressStep: View {
                         .frame(width: 6, height: 6)
                 }
             }
+            .animation(.easeInOut(duration: 0.3), value: done)
+            .animation(.easeInOut(duration: 0.3), value: active)
+
             Text(label)
                 .font(.system(size: 12, weight: done ? .medium : .regular))
                 .foregroundStyle(done ? Color.textPrimary : active ? Color.accentCyan.opacity(0.8) : Color.textTertiary)
+                .animation(.easeInOut(duration: 0.3), value: done)
             Spacer()
         }
     }

--- a/mobile/AnalyzingView.swift
+++ b/mobile/AnalyzingView.swift
@@ -98,11 +98,6 @@ struct AnalyzingView: View {
                             .foregroundStyle(Color.accentCyan)
                             .frame(width: 24, alignment: .leading)
                     }
-
-                    Text(stepDescription(vm.analysisStep))
-                        .font(.system(size: 13))
-                        .foregroundStyle(Color.textSecondary)
-                        .animation(.easeInOut(duration: 0.3), value: vm.analysisStep)
                 }
 
                 // Progress steps — driven by real backend steps
@@ -133,19 +128,6 @@ struct AnalyzingView: View {
         }
         .onReceive(timer) { _ in
             dots = (dots + 1) % 4
-        }
-    }
-
-    // Human-readable description for each backend step
-    private func stepDescription(_ step: Int) -> String {
-        switch step {
-        case 0:  return "Łączenie z serwerem..."
-        case 1:  return "Obraz odebrany — inicjalizacja modeli"
-        case 2:  return "Ładowanie modeli AI (YOLO i UNet)"
-        case 3:  return "Model AI przetwarza obraz dna oka"
-        case 4:  return "Nakładanie masek segmentacji"
-        case 5:  return "Analiza zakończona pomyślnie"
-        default: return "Przetwarzanie..."
         }
     }
 }

--- a/mobile/ContentView.swift
+++ b/mobile/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
                     .transition(.opacity)
 
             case .analyzing:
-                AnalyzingView()
+                AnalyzingView(vm: vm)
                     .transition(.opacity)
 
             case .result(let result):
@@ -29,7 +29,6 @@ struct ContentView: View {
         .animation(.easeInOut(duration: 0.35), value: screenKey)
     }
 
-    // helper for animation value
     private var screenKey: String {
         switch vm.screen {
         case .home:      return "home"

--- a/mobile/GlaucomaService.swift
+++ b/mobile/GlaucomaService.swift
@@ -16,6 +16,14 @@ struct GlaucomaResult: Codable {
     }
 }
 
+// Streaming progress model
+struct StreamProgress: Decodable {
+    let status: String
+    let step: Int?
+    let message: String?
+    let data: GlaucomaResult?
+}
+
 // App State
 enum AppScreen {
     case home
@@ -29,10 +37,62 @@ class GlaucomaService {
     static let shared = GlaucomaService()
     private init() {}
 
-    private let endpoint = "https://glaucoma-a5cpf7arbdetdmax.polandcentral-01.azurewebsites.net/analyze-glaucoma"
+    private let baseURL = "https://glaucoma-a5cpf7arbdetdmax.polandcentral-01.azurewebsites.net"
 
+    // Streaming analyze (NDJSON)
+    func analyzeStreaming(
+        image: UIImage,
+        onStep: @escaping (Int) -> Void
+    ) async throws -> GlaucomaResult {
+        guard let url = URL(string: "\(baseURL)/analyze-glaucoma-stream") else { throw ServiceError.badURL }
+        guard let jpeg = image.jpegData(compressionQuality: 0.9) else { throw ServiceError.encodingFailed }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"eye.jpg\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(jpeg)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (asyncBytes, response) = try await URLSession.shared.bytes(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw ServiceError.serverError
+        }
+
+        var finalResult: GlaucomaResult?
+
+        for try await line in asyncBytes.lines {
+            guard !line.isEmpty,
+                  let data = line.data(using: .utf8) else { continue }
+
+            guard let progress = try? JSONDecoder().decode(StreamProgress.self, from: data) else { continue }
+
+            if let step = progress.step {
+                await MainActor.run { onStep(step) }
+            }
+
+            if progress.status == "success", let result = progress.data {
+                finalResult = result
+            } else if progress.status == "error" {
+                throw ServiceError.serverError
+            }
+        }
+
+        guard let result = finalResult else { throw ServiceError.serverError }
+        return result
+    }
+
+    // Classic (non-streaming) fallback
     func analyze(image: UIImage) async throws -> GlaucomaResult {
-        guard let url = URL(string: endpoint) else { throw ServiceError.badURL }
+        guard let url = URL(string: "\(baseURL)/analyze-glaucoma") else { throw ServiceError.badURL }
         guard let jpeg = image.jpegData(compressionQuality: 0.9) else { throw ServiceError.encodingFailed }
 
         var request = URLRequest(url: url)
@@ -51,8 +111,6 @@ class GlaucomaService {
         request.httpBody = body
 
         let (data, response) = try await URLSession.shared.data(for: request)
-        print("Status:", (response as? HTTPURLResponse)?.statusCode ?? 0)
-        print("Response size:", data.count, "bytes")
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
             throw ServiceError.serverError
         }

--- a/mobile/GlaucomaViewModel.swift
+++ b/mobile/GlaucomaViewModel.swift
@@ -7,12 +7,21 @@ class GlaucomaViewModel: ObservableObject {
     @Published var selectedImage: UIImage?
     @Published var showPicker = false
 
+    /// Current backend step (1–5), drives AnalyzingView progress
+    @Published var analysisStep: Int = 0
+
     func runAnalysis() {
         guard let image = selectedImage else { return }
+        analysisStep = 0
         screen = .analyzing
         Task {
             do {
-                let result = try await GlaucomaService.shared.analyze(image: image)
+                let result = try await GlaucomaService.shared.analyzeStreaming(
+                    image: image,
+                    onStep: { [weak self] step in
+                        self?.analysisStep = step
+                    }
+                )
                 screen = .result(result)
             } catch {
                 screen = .error(error.localizedDescription)
@@ -22,6 +31,7 @@ class GlaucomaViewModel: ObservableObject {
 
     func reset() {
         selectedImage = nil
+        analysisStep = 0
         screen = .home
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Coderabbit's summary:

- **AnalyzingView.swift**: Refactored progress UI to be driven by backend steps via `@ObservedObject var vm: GlaucomaViewModel`. Replaced dots/timer placeholder with explicit `ProgressStep` rows mapped to backend steps 1–5. Added animation modifiers for state transitions.

- **ContentView.swift**: Updated to pass shared `GlaucomaViewModel` instance to `AnalyzingView` for proper state wiring.

- **GlaucomaService.swift**: Added new `analyzeStreaming(image:onStep:)` async function that streams NDJSON progress updates via multipart upload, invoking callback for each step received. Refactored existing `analyze()` to use shared `baseURL`.

- **GlaucomaViewModel.swift**: Added `@Published var analysisStep: Int` property to track backend progress. Updated `runAnalysis()` to use the new streaming API and `reset()` to clear the step counter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->