### PR TITLE
Add old Unet++ model

### DIFF
--- a/ai/.gitignore
+++ b/ai/.gitignore
@@ -5,7 +5,7 @@ env/
 
 # Model weights (do not commit — too large for Git/LFS)
 *.pt
-*.pth
+
 
 # Data and Results
 results/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Coderabbit's summary:
- Removed the `*.pth` ignore rule from `ai/.gitignore`, allowing `.pth` model files to be tracked by Git.
- Kept the existing `*.pt` ignore rule unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->